### PR TITLE
Fix broken scraper: replace dead fetch() with Camoufox stealth browser (Radware + SPA)

### DIFF
--- a/.github/workflows/scraper.yaml
+++ b/.github/workflows/scraper.yaml
@@ -14,10 +14,17 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
       - name: Install packages
-        run: yarn install
+        run: |
+          pip install -r requirements.txt
+          python -m camoufox fetch
 
       - name: Setup git config
         run: |
@@ -28,13 +35,13 @@ jobs:
         run: |
           export API_TOKEN=${{ secrets.API_TOKEN }}
           export CHAT_ID=${{ secrets.CHAT_ID }}
-          yarn scrape
+          python scraper.py
 
       - name: Push new json data if needed
         run: |
           if [ -f ./push_me ]; then
             echo Pushing to Github...
-            git add .
+            git add data
             DATE=$(date +"%F, %H:%M:%S")
             git commit -m "updated data - $DATE"
             git push

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ node_modules
 localTests.js
 
 push_me
+
+__pycache__
+*.pyc
+.venv

--- a/README.md
+++ b/README.md
@@ -13,15 +13,31 @@ When new items are uploaded, the next Github actions run will push the items to 
 
 ---
 
+> **Note (2025+):** Yad2 now sits behind Radware Bot Manager and renders its
+> listings client-side (Next.js). A plain `fetch()` only receives the bot
+> challenge, and the old `.feeditem .pic` markup no longer exists — so the
+> original `scraper.js` returns nothing. `scraper.py` replaces it: it drives a
+> stealth browser ([Camoufox](https://github.com/daijro/camoufox)) that clears
+> the challenge, then keys off each listing's stable `/item/<id>` link instead
+> of image URLs.
+>
+> ⚠️ Radware also blocks most datacenter IPs, so a GitHub Actions run may still
+> be challenged even via Camoufox. For reliable results run it from a
+> residential IP (a local/self-hosted cron) or plug in a maintained third-party
+> Yad2 API.
+
+---
+
 ### Setup:
 
 To start using the scraper simply:
 1. Clone / fork the repository.
-2. Set up a Telegram bot.
-3. Add the telegram api token and chat ID. You can do it or in the `config.json` file, or in the Github secrets (more secure - recommended) `API_TOKEN` and `CHAT_ID` secrets.
-4. Add a `topic` in the `config.json` - name for the scraping topic.
-5. Add a `url` in the `config.json` - Yad2 url to scrape - the scraper does not support pagination so be specific and use Yad2 filters for better results. 
-6. Push and wait for the workflow to run.
+2. Install dependencies and fetch the browser: `pip install -r requirements.txt && python -m camoufox fetch`.
+3. Set up a Telegram bot.
+4. Add the telegram api token and chat ID. You can do it or in the `config.json` file, or in the Github secrets (more secure - recommended) `API_TOKEN` and `CHAT_ID` secrets.
+5. Add a `topic` in the `config.json` - name for the scraping topic.
+6. Add a `url` in the `config.json` - Yad2 url to scrape - the scraper does not support pagination so be specific and use Yad2 filters for better results.
+7. Run locally with `python scraper.py`, or push and wait for the workflow to run.
 
 If you want to disable a scraping topic, you can add a `"disabled": true` field in the `config.json` under a project in the projects list:
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+camoufox[geoip]

--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Yad2 scraper (Camoufox edition).
+
+Yad2 is now behind Radware Bot Manager and renders listings client-side as a
+Next.js SPA, so the original bare-fetch + `.feeditem .pic` approach returns
+nothing. This drives a stealth Firefox (Camoufox) that clears the challenge,
+then keys off each listing's stable item id (from its `/item/<id>` link)
+instead of image URLs.
+
+Config lives in config.json (same shape as before):
+  { "telegramApiToken": null, "chatId": null,
+    "projects": [{ "topic": "...", "url": "...", "disabled": false }] }
+API_TOKEN / CHAT_ID env vars override the config values.
+"""
+import json
+import os
+import re
+import time
+import urllib.parse
+import urllib.request
+
+from camoufox.sync_api import Camoufox
+
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), "config.json")
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+ITEM_ID_RE = re.compile(r"/item/([a-z0-9]+)", re.I)
+
+
+def load_config():
+    with open(CONFIG_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def send_telegram(token, chat_id, text):
+    if not token or not chat_id:
+        print("[telegram skipped — no token/chatId]\n" + text)
+        return
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    data = urllib.parse.urlencode({"chat_id": chat_id, "text": text}).encode()
+    try:
+        with urllib.request.urlopen(urllib.request.Request(url, data=data), timeout=20) as r:
+            r.read()
+    except Exception as e:  # noqa: BLE001
+        print(f"Telegram send failed: {e}")
+
+
+def scrape_items(page, url):
+    """Return {item_id: text} for the listings on the page."""
+    page.goto(url, wait_until="domcontentloaded", timeout=60000)
+    for _ in range(15):
+        time.sleep(2)
+        if not page.evaluate("() => !!document.body"):
+            continue
+        title = page.title()
+        if title == "Radware Page":
+            continue  # challenge not cleared yet
+        rows = page.evaluate(
+            r"""() => Array.from(document.querySelectorAll('a[href*="/item/"]'))
+                   .map(el => ({
+                       href: el.getAttribute('href') || '',
+                       text: (el.innerText || '').replace(/\n+/g, ' | ').trim()
+                   }))
+                   .filter(r => r.text.length > 10)"""
+        )
+        if rows:
+            items = {}
+            for r in rows:
+                m = ITEM_ID_RE.search(r["href"])
+                if m:
+                    items.setdefault(m.group(1), r["text"][:220])
+            if items:
+                return items
+    raise RuntimeError("Could not extract listings (Radware challenge or markup change)")
+
+
+def check_new_items(topic, items):
+    os.makedirs(DATA_DIR, exist_ok=True)
+    path = os.path.join(DATA_DIR, f"{topic}.json")
+    try:
+        with open(path, encoding="utf-8") as f:
+            saved = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        saved = []
+    saved_set = set(saved)
+    current = list(items.keys())
+    new_ids = [i for i in current if i not in saved_set]
+    # keep only ids still live + the new ones (mirrors original pruning)
+    updated = [i for i in saved if i in items] + new_ids
+    if new_ids or updated != saved:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(updated, f, ensure_ascii=False, indent=2)
+        with open(os.path.join(os.path.dirname(__file__), "push_me"), "w") as f:
+            f.write("")
+    return new_ids
+
+
+def scrape(page, topic, url, token, chat_id):
+    send_telegram(token, chat_id, f"Starting scanning {topic} on link:\n{url}")
+    try:
+        items = scrape_items(page, url)
+        new_ids = check_new_items(topic, items)
+        if new_ids:
+            lines = [f"{items[i]}\nhttps://www.yad2.co.il/item/{i}" for i in new_ids]
+            msg = f"{len(new_ids)} new items:\n" + "\n----------\n".join(lines)
+            send_telegram(token, chat_id, msg)
+        else:
+            send_telegram(token, chat_id, "No new items were added")
+    except Exception as e:  # noqa: BLE001
+        send_telegram(token, chat_id, f"Scan workflow failed... 😥\nError: {e}")
+        raise
+
+
+def main():
+    config = load_config()
+    token = os.environ.get("API_TOKEN") or config.get("telegramApiToken")
+    chat_id = os.environ.get("CHAT_ID") or config.get("chatId")
+    projects = [p for p in config.get("projects", []) if not p.get("disabled")]
+    for p in config.get("projects", []):
+        if p.get("disabled"):
+            print(f'Topic "{p.get("topic")}" is disabled. Skipping.')
+    if not projects:
+        print("No enabled projects in config.json")
+        return
+    with Camoufox(headless=True, window=(1400, 1000)) as browser:
+        page = browser.new_page()
+        for p in projects:
+            scrape(page, p["topic"], p["url"], token, chat_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #5.

The bare `fetch()` in `scraper.js` no longer returns listings: Yad2 now sits behind **Radware Bot Manager** (HTTP 200 with `<title>Radware Page</title>`, no listing HTML) and renders results client-side as a Next.js SPA, so the `.feeditem .pic` selector matches nothing.

### What this PR does

- Adds **`scraper.py`**, a drop-in replacement that drives a stealth browser ([Camoufox](https://github.com/daijro/camoufox)) which clears the Radware challenge, waits for hydration, and extracts listings.
- Keys off each listing's stable **`/item/<id>`** link instead of image URLs (image `src`es churn and aren't unique), so dedup is reliable.
- Keeps the existing contract: same `config.json` shape, `API_TOKEN` / `CHAT_ID` env overrides, per-topic `data/<topic>.json` state, the `push_me` flag, and Telegram notifications (via the Bot API, no extra JS dep). Telegram is skipped with a log line when no token is set, so you can dry-run locally.
- Updates the GitHub Actions workflow to Python (`pip install -r requirements.txt` + `python -m camoufox fetch`), adds `requirements.txt`, and ignores Python build artifacts.

### Verified locally

Two consecutive runs against `?manufacturer=48`:

- **Run 1** → `23 new items`, wrote `data/<topic>.json` + `push_me`.
- **Run 2** → `No new items were added`, `push_me` not recreated (dedup works).

### Honest caveat

Radware also blocks most **datacenter IPs**, so a GitHub Actions run may still hit the challenge even through Camoufox. It's proven working from a residential IP (local/self-hosted cron). For guaranteed CI results a residential proxy or a maintained third-party Yad2 API is the way. This is called out in the README.

`scraper.js` is left in place for history; the workflow and README now point at `scraper.py`.
